### PR TITLE
Support no nvidia enrironment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 ROS_DISTRO ?= noetic
 TARGET_WS  :=
+NVIDIA_DOCKER ?= false
+DOCKER_COMPOSE_FILE := docker-compose.yml
+
+ifeq ($(NVIDIA_DOCKER), true)
+	DOCKER_COMPOSE_FILE := docker-compose.nvidia.yml
+endif
 
 install:
 	@if [ -z "$(TARGET_WS)" ]; then echo "Please specify the target ROS workspace to install."; exit 1; fi
@@ -7,4 +13,6 @@ install:
 	mkdir -p $(TARGET_WS)/cache/$(ROS_DISTRO)/build
 	mkdir -p $(TARGET_WS)/cache/$(ROS_DISTRO)/install
 	mkdir -p $(TARGET_WS)/cache/$(ROS_DISTRO)/log
-	cp -r $(ROS_DISTRO)/. $(TARGET_WS)/src/.devcontainer
+	cp -r $(ROS_DISTRO)/devcontainer.json $(TARGET_WS)/src/.devcontainer/devcontainer.json
+	cp -r $(ROS_DISTRO)/Dockerfile $(TARGET_WS)/src/.devcontainer/Dockerfile
+	cp -r $(ROS_DISTRO)/$(DOCKER_COMPOSE_FILE) $(TARGET_WS)/src/.devcontainer/docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ```
 git clone git@github.com:amslabtech/amsl_ros_docker_ws.git
 cd amsl_ros_docker_ws
-make install TARGET_WS=<ROS_workspace> ROS_DISTRO=noetic
+make install TARGET_WS=<ROS_workspace> ROS_DISTRO=noetic NVIDIA_DOCKER=false
 ```
 
 セットアップ後、ディレクトリ構成は以下のようになる。

--- a/humble/docker-compose.nvidia.yml
+++ b/humble/docker-compose.nvidia.yml
@@ -1,17 +1,22 @@
 version: "3.8"
 
 services:
-  ros-noetic-docker-ws:
+  ros-humble-docker-ws:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        - ROS_DISTRO=noetic
+        - ROS_DISTRO=humble
     working_dir: /home/user/ws
     network_mode: "host"
+    ipc: host
     privileged: true
     environment:
       - DISPLAY=${DISPLAY}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - __NV_PRIME_RENDER_OFFLOAD=1
+      - __GLX_VENDOR_LIBRARY_NAME=nvidia
     volumes:
       - type: bind
         source: /tmp/.X11-unix
@@ -23,13 +28,13 @@ services:
         source: ..
         target: /home/user/ws/src
       - type: bind
-        source: ../../cache/noetic/build
+        source: ../../cache/humble/build
         target: /home/user/ws/build
       - type: bind
-        source: ../../cache/noetic/install
+        source: ../../cache/humble/install
         target: /home/user/ws/install
       - type: bind
-        source: ../../cache/noetic/log
+        source: ../../cache/humble/log
         target: /home/user/ws/log
       - type: volume
         source: apt-cache-apt-lists
@@ -39,9 +44,16 @@ services:
         target: /var/cache/apt/archives
     tty: true
     command: /bin/bash -c "sudo apt update && sudo rosdep update && sudo rosdep install -riy --from-paths src && bash"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 
 volumes:
   apt-cache-apt-lists:
-    name: ros-noetic-apt-cache-apt-lists
+    name: ros-humble-apt-cache-apt-lists
   apt-cache-apt-archives:
-    name: ros-noetic-apt-cache-apt-archives
+    name: ros-humble-apt-cache-apt-archives

--- a/humble/docker-compose.yml
+++ b/humble/docker-compose.yml
@@ -13,10 +13,6 @@ services:
     privileged: true
     environment:
       - DISPLAY=${DISPLAY}
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=all
-      - __NV_PRIME_RENDER_OFFLOAD=1
-      - __GLX_VENDOR_LIBRARY_NAME=nvidia
     volumes:
       - type: bind
         source: /tmp/.X11-unix
@@ -44,13 +40,6 @@ services:
         target: /var/cache/apt/archives
     tty: true
     command: /bin/bash -c "sudo apt update && sudo rosdep update && sudo rosdep install -riy --from-paths src && bash"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 volumes:
   apt-cache-apt-lists:

--- a/noetic/docker-compose.nvidia.yml
+++ b/noetic/docker-compose.nvidia.yml
@@ -12,6 +12,10 @@ services:
     privileged: true
     environment:
       - DISPLAY=${DISPLAY}
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - __NV_PRIME_RENDER_OFFLOAD=1
+      - __GLX_VENDOR_LIBRARY_NAME=nvidia
     volumes:
       - type: bind
         source: /tmp/.X11-unix
@@ -39,6 +43,13 @@ services:
         target: /var/cache/apt/archives
     tty: true
     command: /bin/bash -c "sudo apt update && sudo rosdep update && sudo rosdep install -riy --from-paths src && bash"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 
 volumes:
   apt-cache-apt-lists:


### PR DESCRIPTION
- docker-compose.ymlをnvidia対応のものとそうでないものに分けた
- makeのオプションを追加し、`NVIDIA_DOCKER=true`のときだけnvidia対応のdocker-compose.ymlを配置するようにした