### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 
 install:
 	@if [ -z "$(TARGET_WS)" ]; then echo "Please specify the target ROS workspace to install."; exit 1; fi
-	mkdir -p $(TARGET_WS)/src
+	mkdir -p $(TARGET_WS)/src/.devcontainer
 	mkdir -p $(TARGET_WS)/cache/$(ROS_DISTRO)/build
 	mkdir -p $(TARGET_WS)/cache/$(ROS_DISTRO)/install
 	mkdir -p $(TARGET_WS)/cache/$(ROS_DISTRO)/log


### PR DESCRIPTION
$(TARGET_WS)/srcに.devcontainerが存在しないため、エラー